### PR TITLE
#24 Create pull request and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,0 +1,12 @@
+# Description
+
+_Describe what you expect the code to do..._
+
+# Details and resources
+
+_Provide as much detail about this proposed change as you can, including links to lines of code, issues, PRs, and external resources where possible..._
+
+# Checklist
+
+- [ ] This issue is linked to the appropriate project.
+- [ ] This issue has appropriate labels.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# What
+
+_Describe what does this pull request propose to add or change?_
+
+# Why
+
+_Why is this pull request necessary for the project?_
+
+# How
+
+_How does this pull request implement the functionality?_
+
+# Covers
+
+_Please include the issue numbers related to this pull request, eg. #8_
+
+- #Issue Number
+
+# Checklist
+
+- [ ] Are the issues being addressed linked to this PR?
+- [ ] Do all commit messages start with the issue number?
+- [ ] Are all code changes sufficiently tested?
+- [ ] Are there screenshots for UI changes?
+
+# Screenshots
+
+## Desktop view
+
+## Mobile view


### PR DESCRIPTION
# What

This PR adds the templates for pull request and issue. I referred to the previous pull requests as well as other open-source projects for creating the templates. There are two ways to create issue template: using Github's issue template builder or creating an issue-template.md manually. This PR uses the second method for creating the issue template.

# Why

This PR acts as a guideline for contributors to include necessary information for new issues and pull requests.

# How

By providing templates when contributors create new issues and pull requests.

# Covers

- #24 

# Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?