### PR TITLE
feature(#36) Add in Hub page

### DIFF
--- a/src/components/button/HubPageButton.jsx
+++ b/src/components/button/HubPageButton.jsx
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import { styled } from '@mui/material/styles'
+import { Link } from 'react-router-dom';
+import { Container, Typography } from '@mui/material';
+
+const StyledLink = styled(Link)(({ theme }) => ({
+    backgroundColor: theme.palette.primary.main,
+    border: `2px solid ${theme.palette.secondary.main}`,
+    color: theme.palette.text.primary,
+    textAlign: "center",
+    boxShadow: "0 0 10px 0 rgba(0, 0, 0, 0.5)",
+    lineHeight: "100px",
+    borderRadius: "50px",
+    textDecoration: "none",
+    width: "300px",
+    display: "block"
+}))
+  
+
+const HubPageButton = ({link, text}) => {
+    return <StyledLink to={link}>
+        <Typography as="span" fontFamily={"Walter Turncoat"} fontSize={20}>{text}</Typography>
+    </StyledLink>
+}
+
+HubPageButton.propTypes = {
+    link: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+}
+
+export default HubPageButton

--- a/src/components/button/HubPageButton.jsx
+++ b/src/components/button/HubPageButton.jsx
@@ -9,11 +9,16 @@ const StyledLink = styled(Link)(({ theme }) => ({
     color: theme.palette.text.primary,
     textAlign: "center",
     boxShadow: "0 0 10px 0 rgba(0, 0, 0, 0.5)",
-    lineHeight: "100px",
-    borderRadius: "50px",
+    lineHeight: "25px",
+    borderRadius: "5px",
     textDecoration: "none",
-    width: "300px",
-    display: "block"
+    width: "200px",
+    display: "block",
+    [theme.breakpoints.up('sm')]: {
+        width: "300px",
+        borderRadius: "50px",
+        lineHeight: "100px",
+    }
 }))
   
 

--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -192,8 +192,8 @@ const NavBar = ({ title, content }, props) => {
 
   return (
     <>
-      <Box sx={{ display: "flex" }}>
-        <Box sx={{ display: { xs: "none", sm: "block" } }}>
+      <Box className="aaa" sx={{ display: "flex" }}>
+        <Box sx={{ display: { xs: "none", sm: "block" }, width: 0 }}>
           <CssBaseline />
           <AppBar position="fixed" open={open}>
             <Toolbar sx={theme.typography.title}>
@@ -204,7 +204,7 @@ const NavBar = ({ title, content }, props) => {
               )}
             </Toolbar>
           </AppBar>
-          <Box
+          <Box className="aaa3"
             component="nav"
             sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
             aria-label="sidebar navigation"

--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -192,7 +192,7 @@ const NavBar = ({ title, content }, props) => {
 
   return (
     <>
-      <Box className="aaa" sx={{ display: "flex" }}>
+      <Box sx={{ display: "flex", padding: 0}}>
         <Box sx={{ display: { xs: "none", sm: "block" }, width: 0 }}>
           <CssBaseline />
           <AppBar position="fixed" open={open}>
@@ -204,7 +204,7 @@ const NavBar = ({ title, content }, props) => {
               )}
             </Toolbar>
           </AppBar>
-          <Box className="aaa3"
+          <Box
             component="nav"
             sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
             aria-label="sidebar navigation"

--- a/src/components/page/Page.jsx
+++ b/src/components/page/Page.jsx
@@ -5,10 +5,15 @@ import PropTypes from "prop-types";
 
 import { styled } from "@mui/material/styles";
 
-const StyledContainer = styled(Container)({
+const StyledContainer = styled(Container)(({ theme }) => ({
   paddingTop: "30px",
   backgroundColor: "inherit",
-});
+  // Full width minus the width of the drawer
+  width: "calc(100vw - 190px)",
+  [theme.breakpoints.up('sm')]: {
+    paddingLeft: "60px",
+  }
+}));
 
 const Page = ({ title, children }) => {
   return (

--- a/src/components/page/Page.jsx
+++ b/src/components/page/Page.jsx
@@ -8,8 +8,7 @@ import { styled } from "@mui/material/styles";
 const StyledContainer = styled(Container)(({ theme }) => ({
   paddingTop: "30px",
   backgroundColor: "inherit",
-  // Full width minus the width of the drawer
-  width: "calc(100vw - 190px)",
+  // Push right for drawer
   [theme.breakpoints.up('sm')]: {
     paddingLeft: "60px",
   }

--- a/src/pages/HubPage.jsx
+++ b/src/pages/HubPage.jsx
@@ -1,0 +1,70 @@
+import { Container, Grid } from "@mui/material";
+import Page from "../components/page/Page";
+import HubPageButton from "../components/button/HubPageButton";
+
+// Move routes into buttons variable on the line below
+const buttons = [
+  {
+    link: "/dashboard",
+    text: "Dashboard",
+  },
+  {
+    link: "/headmate-meeting-space",
+    text: "Headmate Meeting Space",
+  },
+  {
+    link: "/system-map",
+    text: "System Map",
+  },
+  {
+    link: "/expressway",
+    text: "Expressway",
+  },
+  {
+    link: "/reminders",
+    text: "Reminders",
+  },
+  {
+    link: "/system-rules",
+    text: "System Rules",
+  },
+  {
+    link: "/appreciation-station",
+    text: "Appreciation Station",
+  },
+  {
+    link: "/treatment-hub",
+    text: "Treatment Hub",
+  },
+  {
+    link: "/resources",
+    text: "Resources",
+  },
+  {
+    link: "/guide",
+    text: "Guide",
+  },
+  {
+    link: "/settings",
+    text: "Settings",
+  },
+  {
+    link: "/leave-a-review",
+    text: "Leave a Review",
+  },
+];
+
+
+const HubPage = () => {
+  return (
+    <Page>
+      <Grid container spacing={4}>
+        {buttons.map((button) => (
+          <Grid item l={4} key={button.link}><HubPageButton key={button.link} link={button.link} text={button.text} /> </Grid>
+        ))}
+      </Grid>
+    </Page>
+  );
+};
+
+export default HubPage;

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from "react-router-dom";
 import EyeAccountCreationPage from "../pages/eyeAccount/EyeAccountCreationPage";
 import SystemMapListingPage from "../pages/systemMap/SystemMapListingPage";
+import HubPage from "../pages/HubPage";
 // routes
 const routes = [
   {
@@ -11,7 +12,7 @@ const routes = [
   {
     path: "/",
     exact: true,
-    element: () => "Hub page TBC",
+    element: () => <HubPage/>,
   },
   {
     path: "/dashboard",


### PR DESCRIPTION
# What
This adds in the hub page using the existing navigation links.

# Why
Because it adds a central page for other parts of the app to link to

# How
By adding a 3 column grid of button that underflows as the screen gets smaller .


# Covers
#36 

# Checklist

- [ ] Are the issues being addressed linked to this PR?
- [ ] Do all commit messages start with the issue number?
- [ ] Are all code changes sufficiently tested?
- [ ] Are there screenshots for UI changes?

# Screenshots

## Desktop view
![image](https://user-images.githubusercontent.com/17767073/211390143-339457e9-1cfd-495d-b147-0e7432aaae4a.png)

## Mobile view
![image](https://user-images.githubusercontent.com/17767073/211394132-2760f74b-d2b6-4522-a557-94e8fd868a64.png)
